### PR TITLE
RWMutex and Iter()/IterBuffered().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 
 go:
-  - 1.5
+  - 1.6

--- a/get.go
+++ b/get.go
@@ -1,11 +1,43 @@
 package ttlcache
 
 func (t *TTLCache) Get(key string) interface{} {
-    t.lock.RLock()
+	t.lock.RLock()
 	defer t.lock.RUnlock()
+
 	if k, ok := t.data[key]; ok {
 		return k.Value
 	}
 
 	return nil
+}
+
+type Tuple struct {
+	Key string
+	Val interface{}
+}
+
+func (t *TTLCache) Iter() <-chan Tuple {
+	ch := make(chan Tuple)
+	go func() {
+		t.lock.RLock()
+		for key, val := range t.data {
+			ch <- Tuple{key, val.Value}
+		}
+		t.lock.RUnlock()
+		close(ch)
+	}()
+	return ch
+}
+
+func (t *TTLCache) IterBuffered() <-chan Tuple {
+	ch := make(chan Tuple, len(t.data))
+	go func() {
+		t.lock.RLock()
+		for key, val := range t.data {
+			ch <- Tuple{key, val.Value}
+		}
+		t.lock.RUnlock()
+		close(ch)
+	}()
+	return ch
 }

--- a/get.go
+++ b/get.go
@@ -1,6 +1,8 @@
 package ttlcache
 
 func (t *TTLCache) Get(key string) interface{} {
+    t.lock.RLock()
+	defer t.lock.RUnlock()
 	if k, ok := t.data[key]; ok {
 		return k.Value
 	}

--- a/reap.go
+++ b/reap.go
@@ -1,9 +1,8 @@
 package ttlcache
 
 import (
-	"time"
-
 	log "github.com/Sirupsen/logrus"
+	"time"
 )
 
 func (t *TTLCache) reap() {

--- a/set.go
+++ b/set.go
@@ -5,12 +5,15 @@ import (
 )
 
 func (t *TTLCache) Set(key string, val interface{}) error {
-	k := &Key{
+    k := &Key{
 		Value: val,
 	}
 	// update key
 	k.updated = time.Now()
 
+    t.lock.Lock()
+	defer t.lock.Unlock()
+	
 	t.data[key] = k
 
 	return nil

--- a/set.go
+++ b/set.go
@@ -5,15 +5,15 @@ import (
 )
 
 func (t *TTLCache) Set(key string, val interface{}) error {
-    k := &Key{
+	k := &Key{
 		Value: val,
 	}
 	// update key
 	k.updated = time.Now()
 
-    t.lock.Lock()
+	t.lock.Lock()
 	defer t.lock.Unlock()
-	
+
 	t.data[key] = k
 
 	return nil

--- a/ttlcache.go
+++ b/ttlcache.go
@@ -14,7 +14,7 @@ type Key struct {
 type TTLCache struct {
 	data         map[string]*Key
 	ttl          time.Duration
-	lock         *sync.Mutex
+	lock         *sync.RWMutex
 	reapCallback func(key string, val interface{})
 }
 
@@ -26,7 +26,7 @@ func NewTTLCache(ttl time.Duration) (*TTLCache, error) {
 	c := &TTLCache{
 		data:         map[string]*Key{},
 		ttl:          ttl,
-		lock:         &sync.Mutex{},
+		lock:         &sync.RWMutex{},
 		reapCallback: func(key string, val interface{}) {},
 	}
 

--- a/ttlcache_test.go
+++ b/ttlcache_test.go
@@ -1,7 +1,6 @@
 package ttlcache
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 	"time"

--- a/ttlcache_test.go
+++ b/ttlcache_test.go
@@ -1,6 +1,8 @@
 package ttlcache
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -116,4 +118,66 @@ func TestSetUpdate(t *testing.T) {
 		t.Fatalf("expected value %s; received %s", nv, r)
 	}
 
+}
+
+type Animal struct {
+	name string
+}
+
+func TestIterator(t *testing.T) {
+	ttl := time.Second * 2000
+
+	c, err := NewTTLCache(ttl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert 100 elements.
+	for i := 0; i < 100; i++ {
+		c.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+
+	counter := 0
+	// Iterate over elements.
+	for item := range c.Iter() {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != 100 {
+		t.Error("We should have counted 100 elements.")
+	}
+}
+
+func TestBufferedIterator(t *testing.T) {
+	ttl := time.Second * 2000
+
+	c, err := NewTTLCache(ttl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert 100 elements
+	for i := 0; i < 100; i++ {
+		c.Set(strconv.Itoa(i), Animal{strconv.Itoa(i)})
+	}
+
+	counter := 0
+	// Iterate over elements
+	for item := range c.IterBuffered() {
+		val := item.Val
+
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != 100 {
+		t.Error("We should have counted 100 elements.")
+	}
 }


### PR DESCRIPTION
Would love your feedback on these changes and if you think they are worth adding.
1. Switched to RWMutex instead of Mutex to hopefully benefit certain use cases where there may be many more Get calls compared to Set calls.
2. Added Iter() and IterBuffered() calls to allow iteration over the map. 

I got the inspiration from [streamrail/concurrent-map](https://github.com/streamrail/concurrent-map). Actually thinking it might be worth investigating a version of your ttlcache which forgoes the Mutex, but instead uses the concurrent-map. For now, I thought these changes were good enough. I'll let you know if I make a feature branch in my fork with the ttlcache/concurrent-map combo.
